### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.so
+venv/
+data/
+model/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 7860
+
+CMD ["python", "main.py", "--max_loops", "0"]

--- a/README.md
+++ b/README.md
@@ -49,3 +49,27 @@ To stop the program, press `Ctrl+C`.
 - Training data is accumulated in `data/training_data.txt`. You can remove or
   edit this file to reset the training history.
 
+
+## Docker
+
+You can run the project inside a Docker container instead of installing Python
+and dependencies locally.
+
+Build the image:
+
+```bash
+docker build -t self-improving-ai .
+```
+
+Then run it, mounting your local `data` and `model` directories so the training
+state persists between runs:
+
+```bash
+docker run -it --rm -p 7860:7860 \
+  -v $(pwd)/data:/app/data \
+  -v $(pwd)/model:/app/model \
+  self-improving-ai
+```
+
+The container launches `python main.py --max_loops 0` by default and exposes
+the Gradio interface on port 7860.


### PR DESCRIPTION
## Summary
- add Dockerfile and `.dockerignore`
- document Docker usage in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6846d96ad840832280c9531bda189b1e