### PR TITLE
Switch to Qwen3-8B base model

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ continuously looks for new text files in `./data/incoming`. When new files are
 found, their content is appended to a training dataset and the model performs a
 brief fine-tuning step. The updated model is saved to `./model`.
 
-The default base model is `mistralai/Devstral-Small-2505` from the Hugging Face
-hub. Because the training loop runs in small increments, you can fine-tune and
-save your model locally.
+The default base model is `Qwen/Qwen3-8B` from the Hugging Face hub. Because the
+training loop runs in small increments, you can fine-tune and save your model
+locally.
 
 ## Usage
 
@@ -43,9 +43,8 @@ To stop the program, press `Ctrl+C`.
 
 ## Notes
 
-- The example uses `mistralai/Devstral-Small-2505`. This model is large, so you
-  may need to experiment with batch size or quantization to fit it on your
-  hardware.
+- The example uses `Qwen/Qwen3-8B`. This model is large, so you may need to
+  experiment with batch size or quantization to fit it on your hardware.
 - Training data is accumulated in `data/training_data.txt`. You can remove or
   edit this file to reset the training history.
 

--- a/main.py
+++ b/main.py
@@ -84,8 +84,8 @@ def main():
         tokenizer = AutoTokenizer.from_pretrained(args.model_path)
         model = AutoModelForCausalLM.from_pretrained(args.model_path)
     else:
-        tokenizer = AutoTokenizer.from_pretrained('mistralai/Devstral-Small-2505')
-        model = AutoModelForCausalLM.from_pretrained('mistralai/Devstral-Small-2505')
+        tokenizer = AutoTokenizer.from_pretrained('Qwen/Qwen3-8B')
+        model = AutoModelForCausalLM.from_pretrained('Qwen/Qwen3-8B')
 
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token


### PR DESCRIPTION
## Summary
- set `Qwen/Qwen3-8B` as the default base model in README and code

## Testing
- `python -m py_compile main.py`
- `python main.py --max_loops 1 --steps_per_loop 1 --sleep_secs 0 --batch_size 1` *(fails: attempted to download model but requires huge files and network errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846db761f14832287222dd2b9b67454