### PR TITLE
Enable dry-run testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ mkdir -p data/incoming data/processed
 
 3. Place any `.txt` files you want the model to learn from in `data/incoming`.
 
-4. Run the script:
+4. Run the script (use `--pretrained_model` to override the large default model):
 
 ```bash
-python main.py --max_loops 0
+python main.py --pretrained_model sshleifer/tiny-gpt2 --max_loops 0
 ```
+
+For a quick smoke test without downloading large models, add `--dry_run` to skip
+training entirely.
 
 The `--max_loops 0` argument keeps the program running indefinitely. Each time a
 new file appears in `data/incoming`, the contents will be used to further train
@@ -70,5 +73,7 @@ docker run -it --rm -p 7860:7860 \
   self-improving-ai
 ```
 
-The container launches `python main.py --max_loops 0` by default and exposes
+The container launches `python main.py --pretrained_model sshleifer/tiny-gpt2 --max_loops 0` by default and exposes
 the Gradio interface on port 7860.
+Use `--dry_run` with the container command if you only want to verify that the
+loop logic works without performing any training.

--- a/main.py
+++ b/main.py
@@ -2,66 +2,13 @@ import argparse
 import os
 import time
 import threading
-import torch
-from transformers import (
-    AutoTokenizer,
-    AutoModelForCausalLM,
-    TextDataset,
-    DataCollatorForLanguageModeling,
-    Trainer,
-    TrainingArguments,
-    TrainerCallback,
-)
-
-import gradio as gr
-
-
-from datasets import load_dataset as hf_load_dataset
+# Heavy dependencies are imported lazily to allow a lightweight dry run
 
 
 # Shared progress log accessible by the training loop and the web UI
 progress_log = []
 
 
-class ProgressCallback(TrainerCallback):
-    """Collect training metrics for display in the web UI."""
-
-    def on_log(self, args, state, control, logs=None, **kwargs):
-        if logs is not None:
-            entry = {"step": state.global_step}
-            entry.update(logs)
-            progress_log.append(entry)
-
-
-def launch_ui():
-    """Start the Gradio web UI in a separate thread."""
-    with gr.Blocks() as demo:
-        log_md = gr.Markdown()
-
-        def update():
-            if not progress_log:
-                return "Waiting for training to start..."
-            lines = [
-                f"**Step {p['step']}** - loss: {p.get('loss', 'N/A')}" for p in progress_log[-20:]
-            ]
-            return "\n".join(lines)
-
-        demo.load(update, None, log_md, every=1)
-
-    demo.launch(server_name="0.0.0.0", share=False)
-
-
-def load_local_dataset(file_path: str, tokenizer: AutoTokenizer):
-    """Load and tokenize text from ``file_path``."""
-    ds = hf_load_dataset('text', data_files={'train': file_path})['train']
-
-    def tokenize(batch):
-        return tokenizer(batch['text'], truncation=True, padding='max_length', max_length=128)
-
-    ds = ds.map(tokenize, batched=True)
-    ds = ds.remove_columns(['text'])
-    ds.set_format(type='torch')
-    return ds
 
 
 def main():
@@ -72,7 +19,87 @@ def main():
     parser.add_argument('--steps_per_loop', type=int, default=100)
     parser.add_argument('--sleep_secs', type=int, default=10)
     parser.add_argument('--max_loops', type=int, default=1, help='Number of improvement loops (0 for infinite)')
+    parser.add_argument('--pretrained_model', default='Qwen/Qwen3-8B',
+                        help='HF model to use when no local model is found')
+    parser.add_argument('--dry_run', action='store_true',
+                        help='Skip model downloads and training')
     args = parser.parse_args()
+
+    if args.dry_run:
+        print('Running in dry run mode; skipping model loading and training.')
+        incoming_dir = os.path.join(args.data_dir, 'incoming')
+        processed_dir = os.path.join(args.data_dir, 'processed')
+        os.makedirs(incoming_dir, exist_ok=True)
+        os.makedirs(processed_dir, exist_ok=True)
+        loop = 0
+        while args.max_loops == 0 or loop < args.max_loops:
+            incoming_files = [f for f in os.listdir(incoming_dir) if f.endswith('.txt')]
+            if not incoming_files:
+                print('No new data found. Sleeping...')
+                time.sleep(args.sleep_secs)
+                loop += 1
+                continue
+            print(f'Found {len(incoming_files)} new file(s). Processing (dry run)...')
+            for fname in incoming_files:
+                path = os.path.join(incoming_dir, fname)
+                os.rename(path, os.path.join(processed_dir, fname))
+            progress_log.append({'step': loop, 'loss': 'dry_run'})
+            print('Dry run iteration completed. Waiting for new data...')
+            time.sleep(args.sleep_secs)
+            loop += 1
+        return
+
+
+
+    import torch
+    from transformers import (
+        AutoTokenizer,
+        AutoModelForCausalLM,
+        DataCollatorForLanguageModeling,
+        Trainer,
+        TrainingArguments,
+        TrainerCallback,
+    )
+    import gradio as gr
+    from datasets import load_dataset as hf_load_dataset
+
+    class ProgressCallback(TrainerCallback):
+        """Collect training metrics for display in the web UI."""
+
+        def on_log(self, args, state, control, logs=None, **kwargs):
+            if logs is not None:
+                entry = {"step": state.global_step}
+                entry.update(logs)
+                progress_log.append(entry)
+
+    def launch_ui():
+        """Start the Gradio web UI in a separate thread."""
+        with gr.Blocks() as demo:
+            log_md = gr.Markdown()
+
+            def update():
+                if not progress_log:
+                    return "Waiting for training to start..."
+                lines = [
+                    f"**Step {p['step']}** - loss: {p.get('loss', 'N/A')}" for p in progress_log[-20:]
+                ]
+                return "\n".join(lines)
+
+            demo.load(update, None, log_md, every=1)
+
+        demo.launch(server_name="0.0.0.0", share=False)
+
+    def load_local_dataset(file_path: str, tokenizer: AutoTokenizer):
+        """Load and tokenize text from ``file_path``."""
+        ds = hf_load_dataset('text', data_files={'train': file_path})['train']
+
+        def tokenize(batch):
+            return tokenizer(batch['text'], truncation=True, padding='max_length', max_length=128)
+
+        ds = ds.map(tokenize, batched=True)
+        ds = ds.remove_columns(['text'])
+        ds.set_format(type='torch')
+        return ds
 
     # Start the web UI in a background thread
     threading.Thread(target=launch_ui, daemon=True).start()
@@ -84,8 +111,8 @@ def main():
         tokenizer = AutoTokenizer.from_pretrained(args.model_path)
         model = AutoModelForCausalLM.from_pretrained(args.model_path)
     else:
-        tokenizer = AutoTokenizer.from_pretrained('Qwen/Qwen3-8B')
-        model = AutoModelForCausalLM.from_pretrained('Qwen/Qwen3-8B')
+        tokenizer = AutoTokenizer.from_pretrained(args.pretrained_model)
+        model = AutoModelForCausalLM.from_pretrained(args.pretrained_model)
 
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token


### PR DESCRIPTION
## Summary
- allow choosing a base model with `--pretrained_model`
- introduce `--dry_run` option so script can run without downloading heavy models
- document new CLI arguments

## Testing
- `python main.py --dry_run --max_loops 1`

------
https://chatgpt.com/codex/tasks/task_e_6846dde137a48322b4def60efc630773